### PR TITLE
deployment name removed from thought process

### DIFF
--- a/app/frontend/src/components/AnalysisPanel/ThoughtProcess.tsx
+++ b/app/frontend/src/components/AnalysisPanel/ThoughtProcess.tsx
@@ -18,11 +18,13 @@ export const ThoughtProcess = ({ thoughts }: Props) => {
                         <div className={styles.tStep}>{t.title}</div>
                         <Stack horizontal tokens={{ childrenGap: 5 }}>
                             {t.props &&
-                                (Object.keys(t.props) || []).map((k: any) => (
-                                    <span className={styles.tProp}>
-                                        {k}: {JSON.stringify(t.props?.[k])}
-                                    </span>
-                                ))}
+                                (Object.keys(t.props) || [])
+                                    .filter((k: string) => !k.includes("deployment"))
+                                    .map((k: any) => (
+                                        <span className={styles.tProp}>
+                                            {k}: {JSON.stringify(t.props?.[k])}
+                                        </span>
+                                    ))}
                         </Stack>
                         {Array.isArray(t.description) ? (
                             <SyntaxHighlighter language="json" wrapLongLines className={styles.tCodeBlock}>


### PR DESCRIPTION
## Purpose

This pull removes the deployment name from the analysis panel.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x ] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by [this tutorial](https://learn.microsoft.com/azure/developer/python/get-started-app-chat-template)
which includes deployment, settings and usage instructions. If text or screenshot need to change in the tutorial,
check the box below and notify the tutorial author. A Microsoft employee can do this for you if you're an external contributor.

```
[ ] Yes
[x ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/azure-search-openai-demo/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` and `black` manually on my code.
